### PR TITLE
Configure release.yml to build web

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,14 @@ jobs:
           cache: "yarn"
           cache-dependency-path: ./web/yarn.lock
 
+      - name: Install web
+        run: yarn install
+        working-directory: ./web
+
+      - name: Build web with Yarn
+        run: yarn build
+        working-directory: ./web
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,8 +2,8 @@ release:
   target_commitish: '{{ .Commit }}'
 before:
   hooks:
-    - yarn -v # For debugging. Historical problems with running 1.x yarn. Need >=3.x yarn (berry)
-    - yarn --cwd web build
+    # - yarn -v # For debugging. Historical problems with running 1.x yarn. Need >=3.x yarn (berry)
+    # - yarn --cwd web build # Performed via CI in the GitHub Action release.yml, or manually during a manual release (see README.md)
     - go mod tidy
 builds:
   - env:

--- a/README.md
+++ b/README.md
@@ -37,12 +37,19 @@ Take a look at [an example logstation.conf here](logstation.default.conf).
 
 logstation uses [goreleaser](https://github.com/goreleaser/goreleaser) for all releases   
 
-To build all targets locally you can run   
-`goreleaser build --snapshot --clean`  
+Start by building the web frontend: 
+* `cd web; yarn build`
+
+To build all targets locally you can run the following in the root directory:    
+
+* `goreleaser build --snapshot --clean`  
    
 If you want to build for a specific target you can set environment variables   
-In powershell this would look like:    
-`$env:GOOS="linux"; $env:GOARCH="amd64"; goreleaser build --snapshot --clean --single-target`
+* In bash this would look like:    
+`GOOS=linux GOARCH=amd64 goreleaser build --snapshot --clean --single-target`
+* In powershell this would look like:    
+`$env:GOOS="linux"; $env:GOARCH="amd64"; goreleaser build --snapshot --clean --single-target`   
+   
 
 Reference the [releases](https://github.com/jdrews/logstation/releases) and [.goreleaser.yaml](.goreleaser.yaml) for all officially supported targets. 
 
@@ -53,7 +60,8 @@ Reference the [releases](https://github.com/jdrews/logstation/releases) and [.go
   * `git push origin 2.0.0-beta1`
 * Ensure you have an environment variable with `GITHUB_TOKEN="YOUR_GH_TOKEN"` and minimum of `write:packages` permissions
 * Release!   
-  * `goreleaser release`
+  * `cd web; yarn build`
+  * `cd ..; goreleaser release`
 * Read the [goreleaser quickstart](https://goreleaser.com/quick-start/) for more details
 
 ### Versions ###


### PR DESCRIPTION
Configure release.yml to build web  and remove web building from goreleaser. This is done to bypass issues with github actions latching onto yarn v1 and not switching to yarn 4 berry when doing a `yarn --cwd`